### PR TITLE
:sparkles: make it ssr-friendly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,15 @@
 import { useState, useEffect } from 'react';
 
 const useWindowFocus = () => {
-  const [focused, setFocused] = useState(document.hasFocus());
+  const [focused, setFocused] = useState(false);
 
   useEffect(() => {
-    const onFocus = () => {
-      setFocused(true);
-    };
+    // first render
+    setFocused(document.hasFocus());
 
-    const onBlur = () => {
-      setFocused(false);
-    };
-
+    const onFocus = () => setFocused(true);
+    const onBlur = () => setFocused(false);
+    
     window.addEventListener('focus', onFocus);
     window.addEventListener('blur', onBlur);
 


### PR DESCRIPTION
this was breaking a `gatsby` build, so i thought it might start with `false` and on the first render it would actually pick up the correct value.